### PR TITLE
feat: [met-1112] update tables of pool history and pool info

### DIFF
--- a/src/main/java/org/cardanofoundation/explorer/consumercommon/entity/PoolHistory.java
+++ b/src/main/java/org/cardanofoundation/explorer/consumercommon/entity/PoolHistory.java
@@ -1,18 +1,27 @@
 package org.cardanofoundation.explorer.consumercommon.entity;
 
+import java.math.BigInteger;
 import java.util.Objects;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.ConstraintMode;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import jakarta.validation.constraints.Digits;
 
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
+import org.cardanofoundation.explorer.consumercommon.validation.Lovelace;
 import org.hibernate.Hibernate;
 
 
@@ -29,14 +38,22 @@ import org.hibernate.Hibernate;
 @SuperBuilder(toBuilder = true)
 public class PoolHistory extends BaseEntity {
 
-  @Column(name = "pool_id", nullable = false)
-  private String poolId;
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "pool_id", nullable = false,
+      foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT, name = "none"))
+  @EqualsAndHashCode.Exclude
+  private PoolHash pool;
+
+  @Column(name = "pool_id", updatable = false, insertable = false)
+  private Long poolId;
 
   @Column(name = "epoch_no")
   private Integer epochNo;
 
-  @Column(name = "active_stake")
-  private String activeStake;
+  @Column(name = "active_stake", precision = 20)
+  @Lovelace
+  @Digits(integer = 20, fraction = 0)
+  private BigInteger activeStake;
 
   @Column(name = "active_stake_pct")
   private Double activeStakePct;
@@ -53,14 +70,20 @@ public class PoolHistory extends BaseEntity {
   @Column(name = "margin")
   private Double margin;
 
-  @Column(name = "fixed_cost")
-  private String fixedCost;
+  @Column(name = "fixed_cost", precision = 20)
+  @Lovelace
+  @Digits(integer = 20, fraction = 0)
+  private BigInteger fixedCost;
 
-  @Column(name = "pool_fees")
-  private String poolFees;
+  @Column(name = "pool_fees", precision = 20)
+  @Lovelace
+  @Digits(integer = 20, fraction = 0)
+  private BigInteger poolFees;
 
-  @Column(name = "deleg_rewards")
-  private String delegRewards;
+  @Column(name = "deleg_rewards", precision = 20)
+  @Lovelace
+  @Digits(integer = 20, fraction = 0)
+  private BigInteger delegatorRewards;
 
   @Column(name = "epoch_ros")
   private Double epochRos;

--- a/src/main/java/org/cardanofoundation/explorer/consumercommon/entity/PoolHistoryCheckpoint.java
+++ b/src/main/java/org/cardanofoundation/explorer/consumercommon/entity/PoolHistoryCheckpoint.java
@@ -32,8 +32,8 @@ public class PoolHistoryCheckpoint extends BaseEntity {
   @Column(name = "epoch_checkpoint", nullable = false)
   private Integer epochCheckpoint;
 
-  @Column(name = "earned_reward")
-  private Boolean earnedReward;
+  @Column(name = "is_spendable_reward")
+  private Boolean isSpendableReward;
 
   @Override
   public boolean equals(Object o) {

--- a/src/main/java/org/cardanofoundation/explorer/consumercommon/entity/PoolInfo.java
+++ b/src/main/java/org/cardanofoundation/explorer/consumercommon/entity/PoolInfo.java
@@ -1,18 +1,27 @@
 package org.cardanofoundation.explorer.consumercommon.entity;
 
+import java.math.BigInteger;
 import java.util.Objects;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.ConstraintMode;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import jakarta.validation.constraints.Digits;
 
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
+import org.cardanofoundation.explorer.consumercommon.validation.Lovelace;
 import org.hibernate.Hibernate;
 
 
@@ -28,14 +37,28 @@ import org.hibernate.Hibernate;
 @SuperBuilder(toBuilder = true)
 public class PoolInfo extends BaseEntity {
 
-  @Column(name = "pool_id", nullable = false)
-  private String poolId;
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "pool_id", nullable = false,
+      foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT, name = "none"))
+  @EqualsAndHashCode.Exclude
+  private PoolHash pool;
+
+  @Column(name = "pool_id", updatable = false, insertable = false)
+  private Long poolId;
+
   @Column(name = "fetched_at_epoch", nullable = false)
   private Integer fetchedAtEpoch;
-  @Column(name = "active_stake", nullable = false)
-  private String activeStake;
-  @Column(name = "live_stake", nullable = false)
-  private String liveStake;
+
+  @Column(name = "active_stake", nullable = false, precision = 20)
+  @Lovelace
+  @Digits(integer = 20, fraction = 0)
+  private BigInteger activeStake;
+
+  @Column(name = "live_stake", nullable = false, precision = 20)
+  @Lovelace
+  @Digits(integer = 20, fraction = 0)
+  private BigInteger liveStake;
+
   @Column(name = "live_saturation", nullable = false)
   private Double liveSaturation;
 


### PR DESCRIPTION
Entities changes correspond to changes in the database:
- Change the data type of the column in the tables pool_history, pool_info (column: pool_id, active_stake, fixed_cost, pool_fees, deleg_rewards)
- Change column name in table pool_history_checkpoint (from "earned_reward" to "is_spendable_reward")