### PR TITLE
fix: [MET-1642] drop unique constraint in Reward to avoid conflict with unique index

### DIFF
--- a/src/main/java/org/cardanofoundation/explorer/consumercommon/entity/Reward.java
+++ b/src/main/java/org/cardanofoundation/explorer/consumercommon/entity/Reward.java
@@ -12,7 +12,6 @@ import jakarta.persistence.ForeignKey;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import jakarta.persistence.UniqueConstraint;
 import jakarta.validation.constraints.Digits;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
@@ -23,10 +22,7 @@ import lombok.experimental.SuperBuilder;
 import org.hibernate.Hibernate;
 
 @Entity
-@Table(name = "reward", uniqueConstraints = {
-    @UniqueConstraint(name = "unique_reward",
-        columnNames = {"addr_id", "type", "earned_epoch", "pool_id"})
-})
+@Table(name = "reward")
 @Getter
 @Setter
 @NoArgsConstructor


### PR DESCRIPTION
Ticket: https://cardanofoundation.atlassian.net/browse/MET-1642
Related PR (draft): https://github.com/cardano-foundation/cf-explorer-rewards/pull/79
After this PR's merged, I will change common-explorer version in reward explorer and open PR:  https://github.com/cardano-foundation/cf-explorer-rewards/pull/79